### PR TITLE
Refactor observeValuesMap to return linkedHashMap

### DIFF
--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
@@ -137,14 +137,14 @@ public class RxFirebaseDatabase {
     }
 
     @NonNull
-    public static <T> Observable<Map<String, T>> observeValuesMap(@NonNull final Query query, @NonNull final Class<T> clazz) {
+    public static <T> Observable<LinkedHashMap<String, T>> observeValuesMap(@NonNull final Query query, @NonNull final Class<T> clazz) {
         return Observable.create(new Observable.OnSubscribe<Map<String, T>>() {
             @Override
             public void call(final Subscriber<? super Map<String, T>> subscriber) {
                 query.addListenerForSingleValueEvent(new ValueEventListener() {
                     @Override
                     public void onDataChange(DataSnapshot dataSnapshot) {
-                        Map<String, T> items = new HashMap<String, T>();
+                        LinkedHashMap<String, T> items = new LinkedHashMap<String, T>();
                         for (DataSnapshot childSnapshot : dataSnapshot.getChildren()) {
                             T value = childSnapshot.getValue(clazz);
                             if (value == null) {

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
@@ -138,9 +138,9 @@ public class RxFirebaseDatabase {
 
     @NonNull
     public static <T> Observable<LinkedHashMap<String, T>> observeValuesMap(@NonNull final Query query, @NonNull final Class<T> clazz) {
-        return Observable.create(new Observable.OnSubscribe<Map<String, T>>() {
+        return Observable.create(new Observable.OnSubscribe<LinkedHashMap<String, T>>() {
             @Override
-            public void call(final Subscriber<? super Map<String, T>> subscriber) {
+            public void call(final Subscriber<? super LinkedHashMap<String, T>> subscriber) {
                 query.addListenerForSingleValueEvent(new ValueEventListener() {
                     @Override
                     public void onDataChange(DataSnapshot dataSnapshot) {


### PR DESCRIPTION
Returns a linkedHashMap to ensure the order of the query is preserved.
