### PR TITLE
Adding a observeValue method

### DIFF
--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
@@ -1,7 +1,6 @@
 package com.kelvinapps.rxfirebase;
 
 import android.support.annotation.NonNull;
-
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -9,12 +8,9 @@ import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
 import com.kelvinapps.rxfirebase.exceptions.RxFirebaseDataCastException;
 import com.kelvinapps.rxfirebase.exceptions.RxFirebaseDataException;
-
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-
 import rx.Observable;
 import rx.Subscriber;
 import rx.functions.Action0;
@@ -175,12 +171,12 @@ public class RxFirebaseDatabase {
     }
 
     @NonNull
-    public static <T> Observable<RxFirebaseChildEvent<T>> observeChildrenEvents(@NonNull final Query ref, @NonNull final Class<T> clazz) {
+    public static <T> Observable<RxFirebaseChildEvent<T>> observeChildrenEvents(@NonNull final Query query, @NonNull final Class<T> clazz) {
         return Observable.create(new Observable.OnSubscribe<RxFirebaseChildEvent<T>>() {
             @Override
             public void call(final Subscriber<? super RxFirebaseChildEvent<T>> subscriber) {
                 final ChildEventListener childEventListener =
-                        ref.addChildEventListener(new ChildEventListener() {
+                        query.addChildEventListener(new ChildEventListener() {
 
                             @Override
                             public void onChildAdded(DataSnapshot dataSnapshot, String previousChildName) {
@@ -232,7 +228,7 @@ public class RxFirebaseDatabase {
                 subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
-                        ref.removeEventListener(childEventListener);
+                        query.removeEventListener(childEventListener);
                     }
                 }));
             }

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
@@ -1,6 +1,7 @@
 package com.kelvinapps.rxfirebase;
 
 import android.support.annotation.NonNull;
+
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -8,9 +9,11 @@ import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
 import com.kelvinapps.rxfirebase.exceptions.RxFirebaseDataCastException;
 import com.kelvinapps.rxfirebase.exceptions.RxFirebaseDataException;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+
 import rx.Observable;
 import rx.Subscriber;
 import rx.functions.Action0;

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseDatabaseTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseDatabaseTests.java
@@ -116,6 +116,25 @@ public class RxFirebaseDatabaseTests {
     }
 
     @Test
+    public void testObserveValue() throws InterruptedException {
+
+        TestSubscriber<TestData> testSubscriber = new TestSubscriber<>();
+        RxFirebaseDatabase.observeValue(mockDatabase, TestData.class)
+                .subscribeOn(Schedulers.immediate())
+                .subscribe(testSubscriber);
+
+        ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
+        verify(mockDatabase).addValueEventListener(argument.capture());
+        argument.getValue().onDataChange(mockFirebaseDataSnapshot);
+
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValueCount(1);
+        testSubscriber.assertReceivedOnNext(Collections.singletonList(testData));
+        testSubscriber.assertNotCompleted();
+        testSubscriber.unsubscribe();
+    }
+
+    @Test
     public void testObserveValues() throws InterruptedException {
 
         TestSubscriber<TestData> testSubscriber = new TestSubscriber<>();


### PR DESCRIPTION
This basically mimics the behavior of Query.addValueEventListener() and enables us to continually observe for changes on a value.
