### PR TITLE
Test cleanup and version update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.google.gms:google-services:3.0.0'
     classpath 'me.tatarka:gradle-retrolambda:3.2.5'
     classpath 'com.novoda:bintray-release:0.3.4'

--- a/rxfirebase/build.gradle
+++ b/rxfirebase/build.gradle
@@ -10,12 +10,12 @@ android {
     exclude 'META-INF/NOTICE'
   }
 
-  compileSdkVersion 24
-  buildToolsVersion "24.0.1"
+  compileSdkVersion 25
+  buildToolsVersion "25.0.2"
 
   defaultConfig {
     minSdkVersion 9
-    targetSdkVersion 24
+    targetSdkVersion 25
     versionCode 15
     versionName "0.0.15"
   }
@@ -53,7 +53,7 @@ dependencies {
   provided 'com.google.firebase:firebase-database:9.4.0'
   provided 'com.google.firebase:firebase-storage:9.4.0'
   compile 'io.reactivex:rxjava:1.1.9'
-  compile 'com.android.support:support-annotations:24.1.1'
+  compile 'com.android.support:support-annotations:25.1.0'
 
 
   testCompile 'junit:junit:4.12'

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseAuthTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseAuthTests.java
@@ -13,9 +13,11 @@ import com.google.firebase.database.DataSnapshot;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
 
@@ -29,6 +31,7 @@ import static org.mockito.Mockito.when;
 /**
  * Created by Nick Moskalenko on 28/04/2016.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RxFirebaseAuthTests {
 
     @Mock
@@ -58,21 +61,19 @@ public class RxFirebaseAuthTests {
     @Mock
     private FirebaseUser mockUser;
 
-    private Void mockRes = null;
-
+    @Captor
     private ArgumentCaptor<OnCompleteListener> testOnCompleteListener;
+
+    @Captor
     private ArgumentCaptor<OnSuccessListener> testOnSuccessListener;
+
+    @Captor
     private ArgumentCaptor<OnFailureListener> testOnFailureListener;
 
+    private Void mockRes = null;
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-
-        testOnCompleteListener = ArgumentCaptor.forClass(OnCompleteListener.class);
-        testOnSuccessListener = ArgumentCaptor.forClass(OnSuccessListener.class);
-        testOnFailureListener = ArgumentCaptor.forClass(OnFailureListener.class);
-
         setupTask(mockAuthTask);
         setupTask(mockProviderQueryResultTask);
         setupTask(mockVoidTask);
@@ -86,7 +87,6 @@ public class RxFirebaseAuthTests {
         when(mockAuth.sendPasswordResetEmail("email")).thenReturn(mockVoidTask);
 
         when(mockAuth.getCurrentUser()).thenReturn(mockUser);
-
     }
 
     private <T> void setupTask(Task<T> task) {

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseDatabaseTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseDatabaseTests.java
@@ -9,9 +9,10 @@ import com.kelvinapps.rxfirebase.exceptions.RxFirebaseDataException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.when;
 /**
  * Created by Nick Moskalenko on 28/04/2016.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RxFirebaseDatabaseTests {
 
     @Mock
@@ -52,8 +54,6 @@ public class RxFirebaseDatabaseTests {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-
         testDataList.add(testData);
         testDataMap.put("key", testData);
         testChildEventAdded = new RxFirebaseChildEvent<>("key", testData, "root", RxFirebaseChildEvent.EventType.ADDED);

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseStorageTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseStorageTests.java
@@ -14,9 +14,11 @@ import com.google.firebase.storage.UploadTask;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.InputStream;
@@ -31,14 +33,11 @@ import static org.mockito.Mockito.when;
 /**
  * Created by Nick Moskalenko on 25/05/2016.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RxFirebaseStorageTests {
 
     @Mock
     private StorageReference mockStorageRef;
-
-    private ArgumentCaptor<OnCompleteListener> testOnCompleteListener;
-    private ArgumentCaptor<OnSuccessListener> testOnSuccessListener;
-    private ArgumentCaptor<OnFailureListener> testOnFailureListener;
 
     @Mock
     private Task<Void> mockVoidTask;
@@ -61,7 +60,6 @@ public class RxFirebaseStorageTests {
     @Mock
     private UploadTask mockUploadTask;
 
-
     @Mock
     private Uri uri;
 
@@ -80,28 +78,26 @@ public class RxFirebaseStorageTests {
     @Mock
     private UploadTask.TaskSnapshot uploadSnapshot;
 
-
-    private byte[] bytes;
-
     @Mock
     private StreamDownloadTask.StreamProcessor processor;
 
     @Mock
     private InputStream stream;
 
+    @Captor
+    private ArgumentCaptor<OnCompleteListener> testOnCompleteListener;
+
+    @Captor
+    private ArgumentCaptor<OnSuccessListener> testOnSuccessListener;
+
+    @Captor
+    private ArgumentCaptor<OnFailureListener> testOnFailureListener;
+
+    private byte[] bytes;
     private Void voidData = null;
-
-
-
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-
-        testOnCompleteListener = ArgumentCaptor.forClass(OnCompleteListener.class);
-        testOnSuccessListener = ArgumentCaptor.forClass(OnSuccessListener.class);
-        testOnFailureListener = ArgumentCaptor.forClass(OnFailureListener.class);
-
         setupTask(mockBytesTask);
         setupTask(mockVoidTask);
         setupTask(mockUriTask);

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseUserTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseUserTests.java
@@ -12,9 +12,12 @@ import com.google.firebase.auth.UserProfileChangeRequest;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
 
@@ -27,14 +30,11 @@ import static org.mockito.Mockito.when;
 /**
  * Created by Nick Moskalenko on 24/05/2016.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class RxFirebaseUserTests {
 
     @Mock
     private FirebaseUser mockUser;
-
-    private ArgumentCaptor<OnCompleteListener> testOnCompleteListener;
-    private ArgumentCaptor<OnSuccessListener> testOnSuccessListener;
-    private ArgumentCaptor<OnFailureListener> testOnFailureListener;
 
     @Mock
     private Task<Void> mockTask;
@@ -45,21 +45,28 @@ public class RxFirebaseUserTests {
     @Mock
     private Task<AuthResult> mockAuthResultTask;
 
-
     @Mock
     private UserProfileChangeRequest userProfileChangeRequest;
 
     @Mock
     private GetTokenResult tokenResult;
 
+    @Mock
+    private AuthCredential credential;
+
+    @Mock
+    private AuthResult authResult;
+
+    @Captor
+    private ArgumentCaptor<OnCompleteListener> testOnCompleteListener;
+
+    @Captor
+    private ArgumentCaptor<OnSuccessListener> testOnSuccessListener;
+
+    @Captor
+    private ArgumentCaptor<OnFailureListener> testOnFailureListener;
 
     private Void mockRes = null;
-
-    @Mock
-    AuthCredential credential;
-
-    @Mock
-    AuthResult authResult;
 
 
     @Before


### PR DESCRIPTION
It more style than anything - using the ```@Captor``` annotation for argument captors and the ```MockitoJUnitRunner``` to reduce boilerplate.  Android Studio barked at me about versions along the way also.