### PR TITLE
Remote config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.google.gms:google-services:3.0.0'
     classpath 'me.tatarka:gradle-retrolambda:3.2.5'
     classpath 'com.novoda:bintray-release:0.3.4'

--- a/rxfirebase/build.gradle
+++ b/rxfirebase/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'jacoco-android'
 apply plugin: 'com.novoda.bintray-release'
 
+ext {
+    firebaseVersion = '9.4.0'
+}
+
 android {
 
   packagingOptions {
@@ -10,12 +14,12 @@ android {
     exclude 'META-INF/NOTICE'
   }
 
-  compileSdkVersion 24
-  buildToolsVersion "24.0.1"
+  compileSdkVersion 25
+  buildToolsVersion "25.0.2"
 
   defaultConfig {
     minSdkVersion 9
-    targetSdkVersion 24
+    targetSdkVersion 25
     versionCode 15
     versionName "0.0.15"
   }
@@ -46,14 +50,14 @@ tasks.withType(Test) {
   }
 }
 
-
 dependencies {
 
-  provided 'com.google.firebase:firebase-auth:9.4.0'
-  provided 'com.google.firebase:firebase-database:9.4.0'
-  provided 'com.google.firebase:firebase-storage:9.4.0'
+  provided "com.google.firebase:firebase-auth:$firebaseVersion"
+  provided "com.google.firebase:firebase-database:$firebaseVersion"
+  provided "com.google.firebase:firebase-storage:$firebaseVersion"
+  provided "com.google.firebase:firebase-config:$firebaseVersion"
   compile 'io.reactivex:rxjava:1.1.9'
-  compile 'com.android.support:support-annotations:24.1.1'
+  compile 'com.android.support:support-annotations:25.1.0'
 
 
   testCompile 'junit:junit:4.12'

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RemoteConfigValues.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RemoteConfigValues.java
@@ -1,0 +1,26 @@
+package com.kelvinapps.rxfirebase;
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface RemoteConfigValues {
+    boolean getBoolean(String key);
+
+    byte[] getByteArray(String key);
+
+    double getDouble(String key);
+
+    long getLong(String key);
+
+    String getString(String key);
+
+    FirebaseRemoteConfigValue getValue(String key);
+
+    void setDefaults(int resourceId);
+
+    void setDefaults(Map<String, Object> defaults);
+
+    Set<String> getKeysByPrefix(String prefix);
+}

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseRemoteConfig.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseRemoteConfig.java
@@ -1,0 +1,174 @@
+package com.kelvinapps.rxfirebase;
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
+
+import java.util.Map;
+import java.util.Set;
+
+import rx.Observable;
+import rx.Subscriber;
+
+public class RxFirebaseRemoteConfig implements RemoteConfigValues {
+
+    private final FirebaseRemoteConfig remoteConfig;
+
+    private RxFirebaseRemoteConfig(FirebaseRemoteConfig remoteConfig) {
+        this.remoteConfig = remoteConfig;
+    }
+
+    public Observable<Void> fetch() {
+        return Observable.create(new Observable.OnSubscribe<Void>() {
+            @Override
+            public void call(Subscriber<? super Void> subscriber) {
+                RxHandler.assignOnTask(subscriber, remoteConfig.fetch());
+            }
+        });
+    }
+
+    public Observable<Void> fetch(final long timeout) {
+        return Observable.create(new Observable.OnSubscribe<Void>() {
+            @Override
+            public void call(Subscriber<? super Void> subscriber) {
+                RxHandler.assignOnTask(subscriber, remoteConfig.fetch(timeout));
+            }
+        });
+    }
+
+    @Override
+    public boolean getBoolean(String key) {
+        return remoteConfig.getBoolean(key);
+    }
+
+    @Override
+    public byte[] getByteArray(String key) {
+        return remoteConfig.getByteArray(key);
+    }
+
+    @Override
+    public double getDouble(String key) {
+        return remoteConfig.getDouble(key);
+    }
+
+    @Override
+    public long getLong(String key) {
+        return remoteConfig.getLong(key);
+    }
+
+    @Override
+    public String getString(String key) {
+        return remoteConfig.getString(key);
+    }
+
+    @Override
+    public FirebaseRemoteConfigValue getValue(String key) {
+        return remoteConfig.getValue(key);
+    }
+
+    @Override
+    public void setDefaults(int resourceId) {
+        remoteConfig.setDefaults(resourceId);
+    }
+
+    @Override
+    public void setDefaults(Map<String, Object> defaults) {
+        remoteConfig.setDefaults(defaults);
+    }
+
+    @Override
+    public Set<String> getKeysByPrefix(String prefix) {
+        return remoteConfig.getKeysByPrefix(prefix);
+    }
+
+    public FirebaseRemoteConfigInfo getInfo() {
+        return remoteConfig.getInfo();
+    }
+
+    public boolean activateFetched() {
+        return remoteConfig.activateFetched();
+    }
+
+    public RemoteConfigValues withNamespace(String namespace) {
+        return new ValuesWithNamespace(remoteConfig, namespace);
+    }
+
+    private static class ValuesWithNamespace implements RemoteConfigValues {
+        private final FirebaseRemoteConfig remoteConfig;
+        private final String namespace;
+
+        private ValuesWithNamespace(FirebaseRemoteConfig remoteConfig, String namespace) {
+            this.remoteConfig = remoteConfig;
+            this.namespace = namespace;
+        }
+
+        @Override
+        public boolean getBoolean(String key) {
+            return remoteConfig.getBoolean(key, namespace);
+        }
+
+        @Override
+        public byte[] getByteArray(String key) {
+            return remoteConfig.getByteArray(key, namespace);
+        }
+
+        @Override
+        public double getDouble(String key) {
+            return remoteConfig.getDouble(key, namespace);
+        }
+
+        @Override
+        public long getLong(String key) {
+            return remoteConfig.getLong(key, namespace);
+        }
+
+        @Override
+        public String getString(String key) {
+            return remoteConfig.getString(key, namespace);
+        }
+
+        @Override
+        public FirebaseRemoteConfigValue getValue(String key) {
+            return remoteConfig.getValue(key, namespace);
+        }
+
+        @Override
+        public void setDefaults(int resourceId) {
+            remoteConfig.setDefaults(resourceId, namespace);
+        }
+
+        @Override
+        public void setDefaults(Map<String, Object> defaults) {
+            remoteConfig.setDefaults(defaults, namespace);
+        }
+
+        @Override
+        public Set<String> getKeysByPrefix(String prefix) {
+            return remoteConfig.getKeysByPrefix(prefix, namespace);
+        }
+    }
+
+    public static class Builder {
+        private final FirebaseRemoteConfig remoteConfig;
+
+        public Builder(FirebaseRemoteConfig remoteConfig) {
+            this.remoteConfig = remoteConfig;
+        }
+
+        public RxFirebaseRemoteConfig build() {
+            return new RxFirebaseRemoteConfig(remoteConfig);
+        }
+
+        public Builder enableDebug(boolean enable) {
+            return withSettings(new FirebaseRemoteConfigSettings.Builder()
+                    .setDeveloperModeEnabled(enable)
+                    .build());
+        }
+
+        public Builder withSettings(FirebaseRemoteConfigSettings settings) {
+            remoteConfig.setConfigSettings(settings);
+            return this;
+        }
+    }
+}

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseRemoteConfigTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseRemoteConfigTests.java
@@ -1,0 +1,387 @@
+package com.kelvinapps.rxfirebase;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+
+import rx.Observable;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RxFirebaseRemoteConfigTests {
+
+    @Mock
+    private FirebaseRemoteConfig remoteConfig;
+
+    @Mock
+    private FirebaseRemoteConfigSettings settings;
+
+    @Mock
+    private FirebaseRemoteConfigInfo info;
+
+    @Mock
+    private FirebaseRemoteConfigValue value;
+
+    @Mock
+    private Task<Void> task;
+
+    @Captor
+    private ArgumentCaptor<FirebaseRemoteConfigSettings> settingsCaptor;
+
+    @Captor
+    private ArgumentCaptor<OnCompleteListener> testOnCompleteListener;
+
+    @Captor
+    private ArgumentCaptor<OnSuccessListener> testOnSuccessListener;
+
+    @Captor
+    private ArgumentCaptor<OnFailureListener> testOnFailureListener;
+
+    private RxFirebaseRemoteConfig testObject;
+
+    @Before
+    public void setUp() {
+        setupTask(task);
+
+        testObject = new RxFirebaseRemoteConfig.Builder(remoteConfig).build();
+    }
+
+    private <T> void setupTask(Task<T> task) {
+        when(task.addOnCompleteListener(testOnCompleteListener.capture())).thenReturn(task);
+        when(task.addOnSuccessListener(testOnSuccessListener.capture())).thenReturn(task);
+        when(task.addOnFailureListener(testOnFailureListener.capture())).thenReturn(task);
+    }
+
+    @Test
+    public void builderReturnsAnInstance() {
+        assertNotNull(testObject);
+    }
+
+    @Test
+    public void enableDebugModeViaSettings() {
+        RxFirebaseRemoteConfig.Builder bob = new RxFirebaseRemoteConfig.Builder(remoteConfig);
+
+        RxFirebaseRemoteConfig.Builder step2 = bob.withSettings(settings);
+        assertSame(bob, step2);
+
+        RxFirebaseRemoteConfig config = step2.build();
+        assertNotNull(config);
+
+        verify(remoteConfig).setConfigSettings(settings);
+    }
+
+    @Test
+    public void enableDebugModeDirectly() {
+        RxFirebaseRemoteConfig.Builder bob = new RxFirebaseRemoteConfig.Builder(remoteConfig);
+
+        RxFirebaseRemoteConfig.Builder step2 = bob.enableDebug(true);
+        assertSame(bob, step2);
+
+        RxFirebaseRemoteConfig config = step2.build();
+        assertNotNull(config);
+
+        verify(remoteConfig).setConfigSettings(settingsCaptor.capture());
+        assertTrue(settingsCaptor.getValue().isDeveloperModeEnabled());
+    }
+
+    @Test
+    public void getSimpleBoolean() {
+        String key = UUID.randomUUID().toString();
+        when(remoteConfig.getBoolean(key)).thenReturn(true);
+
+        boolean actual = testObject.getBoolean(key);
+
+        verify(remoteConfig).getBoolean(key);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void getSimpleByteArray() {
+        String key = UUID.randomUUID().toString();
+        byte[] expected = new byte[0];
+        when(remoteConfig.getByteArray(key)).thenReturn(expected);
+
+        byte[] actual = testObject.getByteArray(key);
+
+        verify(remoteConfig).getByteArray(key);
+        assertSame(expected, actual);
+    }
+
+    @Test
+    public void getSimpleDouble() {
+        String key = UUID.randomUUID().toString();
+        double expected = new Random().nextDouble();
+        when(remoteConfig.getDouble(key)).thenReturn(expected);
+
+        double actual = testObject.getDouble(key);
+
+        verify(remoteConfig).getDouble(key);
+        assertEquals(expected, actual, 0.001);
+    }
+
+    @Test
+    public void getSimpleLong() {
+        String key = UUID.randomUUID().toString();
+        long expected = new Random().nextLong();
+        when(remoteConfig.getLong(key)).thenReturn(expected);
+
+        long actual = testObject.getLong(key);
+
+        verify(remoteConfig).getLong(key);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getSimpleString() {
+        String key = UUID.randomUUID().toString();
+        String expected = UUID.randomUUID().toString();
+        when(remoteConfig.getString(key)).thenReturn(expected);
+
+        String actual = testObject.getString(key);
+
+        verify(remoteConfig).getString(key);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getNamespaceBoolean() {
+        String key = UUID.randomUUID().toString();
+        String namespace = UUID.randomUUID().toString();
+        when(remoteConfig.getBoolean(key, namespace)).thenReturn(true);
+
+        boolean actual = testObject.withNamespace(namespace).getBoolean(key);
+
+        verify(remoteConfig).getBoolean(key, namespace);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void getNamespaceByteArray() {
+        String key = UUID.randomUUID().toString();
+        String namespace = UUID.randomUUID().toString();
+        byte[] expected = new byte[0];
+        when(remoteConfig.getByteArray(key, namespace)).thenReturn(expected);
+
+        byte[] actual = testObject.withNamespace(namespace).getByteArray(key);
+
+        verify(remoteConfig).getByteArray(key, namespace);
+        assertSame(expected, actual);
+    }
+
+    @Test
+    public void getNamespaceDouble() {
+        String key = UUID.randomUUID().toString();
+        String namespace = UUID.randomUUID().toString();
+        double expected = new Random().nextDouble();
+        when(remoteConfig.getDouble(key, namespace)).thenReturn(expected);
+
+        double actual = testObject.withNamespace(namespace).getDouble(key);
+
+        verify(remoteConfig).getDouble(key, namespace);
+        assertEquals(expected, actual, 0.001);
+    }
+
+    @Test
+    public void getNamespaceLong() {
+        String key = UUID.randomUUID().toString();
+        String namespace = UUID.randomUUID().toString();
+        long expected = new Random().nextLong();
+        when(remoteConfig.getLong(key, namespace)).thenReturn(expected);
+
+        long actual = testObject.withNamespace(namespace).getLong(key);
+
+        verify(remoteConfig).getLong(key, namespace);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void getNamespaceString() {
+        String key = UUID.randomUUID().toString();
+        String namespace = UUID.randomUUID().toString();
+        String expected = UUID.randomUUID().toString();
+        when(remoteConfig.getString(key, namespace)).thenReturn(expected);
+
+        String actual = testObject.withNamespace(namespace).getString(key);
+
+        verify(remoteConfig).getString(key, namespace);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void setDefaultsFromResources() {
+        int resource = new Random().nextInt();
+
+        testObject.setDefaults(resource);
+
+        verify(remoteConfig).setDefaults(resource);
+    }
+
+    @Test
+    public void setNamespaceDefaultsFromResources() {
+        int resource = new Random().nextInt();
+        String namespace = UUID.randomUUID().toString();
+
+        testObject.withNamespace(namespace).setDefaults(resource);
+
+        verify(remoteConfig).setDefaults(resource, namespace);
+    }
+
+    @Test
+    public void setDefaultsFromMap() {
+        Map<String, Object> resource = new HashMap<>();
+
+        testObject.setDefaults(resource);
+
+        verify(remoteConfig).setDefaults(resource);
+    }
+
+    @Test
+    public void setNamespaceDefaultsFromMap() {
+        Map<String, Object> resource = new HashMap<>();
+        String namespace = UUID.randomUUID().toString();
+
+        testObject.withNamespace(namespace).setDefaults(resource);
+
+        verify(remoteConfig).setDefaults(resource, namespace);
+    }
+
+    @Test
+    public void activateFetched() {
+        when(remoteConfig.activateFetched()).thenReturn(true);
+
+        boolean result = testObject.activateFetched();
+
+        verify(remoteConfig).activateFetched();
+        assertTrue(result);
+    }
+
+    @Test
+    public void getInfo() {
+        when(remoteConfig.getInfo()).thenReturn(info);
+
+        FirebaseRemoteConfigInfo actual = testObject.getInfo();
+
+        verify(remoteConfig).getInfo();
+        assertSame(info, actual);
+    }
+
+    @Test
+    public void getKeysByPrefixWithoutNamespace() {
+        String prefix = UUID.randomUUID().toString();
+        Set<String> expected = new HashSet<>();
+        when(remoteConfig.getKeysByPrefix(prefix)).thenReturn(expected);
+
+        Set<String> actual = testObject.getKeysByPrefix(prefix);
+
+        verify(remoteConfig).getKeysByPrefix(prefix);
+        assertSame(expected, actual);
+    }
+
+    @Test
+    public void getKeysByPrefixWithNamespace() {
+        String prefix = UUID.randomUUID().toString();
+        String namespace = UUID.randomUUID().toString();
+        Set<String> expected = new HashSet<>();
+        when(remoteConfig.getKeysByPrefix(prefix, namespace)).thenReturn(expected);
+
+        Set<String> actual = testObject.withNamespace(namespace).getKeysByPrefix(prefix);
+
+        verify(remoteConfig).getKeysByPrefix(prefix, namespace);
+        assertSame(expected, actual);
+    }
+
+    @Test
+    public void getValue() {
+        String key = UUID.randomUUID().toString();
+        when(remoteConfig.getValue(key)).thenReturn(value);
+
+        FirebaseRemoteConfigValue actual = testObject.getValue(key);
+
+        verify(remoteConfig).getValue(key);
+        assertSame(value, actual);
+    }
+
+    @Test
+    public void getValueWithNamespace() {
+        String key = UUID.randomUUID().toString();
+        String namespace = UUID.randomUUID().toString();
+        when(remoteConfig.getValue(key, namespace)).thenReturn(value);
+
+        FirebaseRemoteConfigValue actual = testObject.withNamespace(namespace).getValue(key);
+
+        verify(remoteConfig).getValue(key, namespace);
+        assertSame(value, actual);
+    }
+
+    @Test
+    public void happyPathFetch() {
+        when(remoteConfig.fetch()).thenReturn(task);
+
+        Observable<Void> observable = testObject.fetch();
+        assertNotNull(observable);
+
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        observable.subscribeOn(Schedulers.immediate()).subscribe(subscriber);
+
+        verify(remoteConfig).fetch();
+        verify(task).addOnCompleteListener(isA(OnCompleteListener.class));
+
+        testOnSuccessListener.getValue().onSuccess(null);
+        testOnCompleteListener.getValue().onComplete(task);
+
+        subscriber.assertNoErrors();
+        subscriber.assertCompleted();
+        assertEquals(1, subscriber.getOnNextEvents().size());
+    }
+
+    @Test
+    public void happyPathFetchWithTimeout() {
+        long timeout = new Random().nextLong();
+        when(remoteConfig.fetch(timeout)).thenReturn(task);
+
+        Observable<Void> observable = testObject.fetch(timeout);
+        assertNotNull(observable);
+
+        TestSubscriber<Void> subscriber = new TestSubscriber<>();
+        observable.subscribeOn(Schedulers.immediate()).subscribe(subscriber);
+
+        verify(remoteConfig).fetch(timeout);
+        verify(task).addOnCompleteListener(isA(OnCompleteListener.class));
+
+        testOnSuccessListener.getValue().onSuccess(null);
+        testOnCompleteListener.getValue().onComplete(task);
+
+        subscriber.assertNoErrors();
+        subscriber.assertCompleted();
+        assertEquals(1, subscriber.getOnNextEvents().size());
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "kelvinapps.com.sample"
         minSdkVersion 9
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -33,10 +33,9 @@ android {
 
 dependencies {
     compile project(':rxfirebase')
-    compile 'com.google.firebase:firebase-auth:9.4.0'
-    compile 'com.google.firebase:firebase-database:9.4.0'
-    compile 'com.google.firebase:firebase-storage:9.4.0'
-    compile 'com.android.support:appcompat-v7:24.1.1'
+
+    compile 'com.android.support:appcompat-v7:25.1.0'
+
     compile 'io.reactivex:rxandroid:1.2.1'
 }
 


### PR DESCRIPTION
I deviated from the official Firebase remote config API with regard to namespaces to reduce duplication - see my ```RemoteConfigValues``` interface.  I'd be happy to roll a version of this code that exactly mirrors their API if you prefer.  The unit tests around ```fetch()``` are a little light (no error cases) but you have already exercised the ```RxHandler``` elsewhere.  If you feel you would like non-happy path tests I can add them.