### PR TITLE
Convert to use RxJava 2.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Build Status](https://circleci.com/gh/nmoskalenko/RxFirebase/tree/master.svg?style=shield)](https://circleci.com/gh/nmoskalenko/RxFirebase/tree/master)
 [![codecov](https://codecov.io/gh/nmoskalenko/rxFirebase/branch/master/graph/badge.svg)](https://codecov.io/gh/nmoskalenko/rxFirebase)
 
-# RxFirebase
+# RxFirebase 2
 
-RxJava wrapper on Google's [Firebase for Android](https://www.firebase.com/docs/android/) library.
+RxJava 2 wrapper on Google's [Firebase for Android](https://www.firebase.com/docs/android/) library.
 
 
 ## Usage
@@ -123,6 +123,7 @@ dependencies {
 
 ## License
     Copyright 2016 Nickolay Moskalenko
+    Adaptation to RxJava 2 - Copyright 2017 Remous-Aris Koutsiamanis
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ RxFirebaseStorage.getBytes(storageRef.child("README.md"), 1024 * 100)
 ##### Gradle:
 ```groovy
 dependencies {
-  compile 'com.google.firebase:firebase-auth:9.4.0'
-  compile 'com.google.firebase:firebase-database:9.4.0'
-  compile 'com.google.firebase:firebase-storage:9.4.0'
+  compile 'com.google.firebase:firebase-auth:10.0.1'
+  compile 'com.google.firebase:firebase-database:10.0.1'
+  compile 'com.google.firebase:firebase-storage:10.0.1'
   compile 'com.kelvinapps:rxfirebase:0.0.15'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0'
+    classpath 'com.android.tools.build:gradle:2.2.0'
     classpath 'com.google.gms:google-services:3.0.0'
     classpath 'me.tatarka:gradle-retrolambda:3.2.5'
     classpath 'com.novoda:bintray-release:0.3.4'

--- a/rxfirebase/build.gradle
+++ b/rxfirebase/build.gradle
@@ -49,16 +49,16 @@ tasks.withType(Test) {
 
 dependencies {
 
-  provided 'com.google.firebase:firebase-auth:9.4.0'
-  provided 'com.google.firebase:firebase-database:9.4.0'
-  provided 'com.google.firebase:firebase-storage:9.4.0'
-  compile 'io.reactivex:rxjava:1.1.9'
+  provided 'com.google.firebase:firebase-auth:10.0.1'
+  provided 'com.google.firebase:firebase-database:10.0.1'
+  provided 'com.google.firebase:firebase-storage:10.0.1'
+  compile 'io.reactivex.rxjava2:rxjava:2.0.4'
   compile 'com.android.support:support-annotations:24.1.1'
 
 
   testCompile 'junit:junit:4.12'
   testCompile "org.mockito:mockito-core:2.0.7-beta"
-  testCompile 'io.reactivex:rxjava:1.1.9'
+  testCompile 'io.reactivex.rxjava2:rxjava:2.0.4'
   testCompile 'org.assertj:assertj-core:1.7.1'
 }
 

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseAuth.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseAuth.java
@@ -8,23 +8,24 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.ProviderQueryResult;
 
-import rx.Observable;
-import rx.Subscriber;
-import rx.functions.Action0;
-import rx.subscriptions.Subscriptions;
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.functions.Cancellable;
 
 /**
  * Created by Nick Moskalenko on 15/05/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseAuth {
 
     @NonNull
     public static Observable<AuthResult> signInAnonymously(@NonNull final FirebaseAuth firebaseAuth) {
-        return Observable.create(new Observable.OnSubscribe<AuthResult>() {
+        return Observable.create(new ObservableOnSubscribe<AuthResult>() {
             @Override
-            public void call(final Subscriber<? super AuthResult> subscriber) {
-                RxHandler.assignOnTask(subscriber, firebaseAuth.signInAnonymously());
-            }
+            public void subscribe(ObservableEmitter<AuthResult> subscriber) throws Exception {
+                  RxHandler.assignOnTask(subscriber, firebaseAuth.signInAnonymously());
+              }
         });
     }
 
@@ -32,33 +33,33 @@ public class RxFirebaseAuth {
     public static Observable<AuthResult> signInWithEmailAndPassword(@NonNull final FirebaseAuth firebaseAuth,
                                                                     @NonNull final String email,
                                                                     @NonNull final String password) {
-        return Observable.create(new Observable.OnSubscribe<AuthResult>() {
+        return Observable.create(new ObservableOnSubscribe<AuthResult>() {
             @Override
-            public void call(final Subscriber<? super AuthResult> subscriber) {
-                RxHandler.assignOnTask(subscriber, firebaseAuth.signInWithEmailAndPassword(email, password));
-            }
+            public void subscribe(ObservableEmitter<AuthResult> subscriber) throws Exception {
+                  RxHandler.assignOnTask(subscriber, firebaseAuth.signInWithEmailAndPassword(email, password));
+              }
         });
     }
 
     @NonNull
     public static Observable<AuthResult> signInWithCredential(@NonNull final FirebaseAuth firebaseAuth,
                                                               @NonNull final AuthCredential credential) {
-        return Observable.create(new Observable.OnSubscribe<AuthResult>() {
+        return Observable.create(new ObservableOnSubscribe<AuthResult>() {
             @Override
-            public void call(final Subscriber<? super AuthResult> subscriber) {
-                RxHandler.assignOnTask(subscriber, firebaseAuth.signInWithCredential(credential));
-            }
+            public void subscribe(ObservableEmitter<AuthResult> subscriber) throws Exception {
+                  RxHandler.assignOnTask(subscriber, firebaseAuth.signInWithCredential(credential));
+              }
         });
     }
 
     @NonNull
     public static Observable<AuthResult> signInWithCustomToken(@NonNull final FirebaseAuth firebaseAuth,
                                                                @NonNull final String token) {
-        return Observable.create(new Observable.OnSubscribe<AuthResult>() {
+        return Observable.create(new ObservableOnSubscribe<AuthResult>() {
             @Override
-            public void call(final Subscriber<? super AuthResult> subscriber) {
-                RxHandler.assignOnTask(subscriber, firebaseAuth.signInWithCustomToken(token));
-            }
+            public void subscribe(ObservableEmitter<AuthResult> subscriber) throws Exception {
+                  RxHandler.assignOnTask(subscriber, firebaseAuth.signInWithCustomToken(token));
+              }
         });
     }
 
@@ -66,31 +67,31 @@ public class RxFirebaseAuth {
     public static Observable<AuthResult> createUserWithEmailAndPassword(@NonNull final FirebaseAuth firebaseAuth,
                                                                         @NonNull final String email,
                                                                         @NonNull final String password) {
-        return Observable.create(new Observable.OnSubscribe<AuthResult>() {
+        return Observable.create(new ObservableOnSubscribe<AuthResult>() {
             @Override
-            public void call(final Subscriber<? super AuthResult> subscriber) {
-                RxHandler.assignOnTask(subscriber, firebaseAuth.createUserWithEmailAndPassword(email, password));
-            }
+            public void subscribe(ObservableEmitter<AuthResult> subscriber) throws Exception {
+                  RxHandler.assignOnTask(subscriber, firebaseAuth.createUserWithEmailAndPassword(email, password));
+              }
         });
     }
 
     @NonNull
     public static Observable<ProviderQueryResult> fetchProvidersForEmail(@NonNull final FirebaseAuth firebaseAuth,
                                                                          @NonNull final String email) {
-        return Observable.create(new Observable.OnSubscribe<ProviderQueryResult>() {
+        return Observable.create(new ObservableOnSubscribe<ProviderQueryResult>() {
             @Override
-            public void call(final Subscriber<? super ProviderQueryResult> subscriber) {
-                RxHandler.assignOnTask(subscriber, firebaseAuth.fetchProvidersForEmail(email));
-            }
+            public void subscribe(ObservableEmitter<ProviderQueryResult> subscriber) throws Exception {
+                  RxHandler.assignOnTask(subscriber, firebaseAuth.fetchProvidersForEmail(email));
+              }
         });
     }
 
     @NonNull
     public static Observable<Void> sendPasswordResetEmail(@NonNull final FirebaseAuth firebaseAuth,
                                                                 @NonNull final String email) {
-        return Observable.create(new Observable.OnSubscribe<Void>() {
+        return Observable.create(new ObservableOnSubscribe<Void>() {
             @Override
-            public void call(final Subscriber<? super Void> subscriber) {
+            public void subscribe(ObservableEmitter<Void> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseAuth.sendPasswordResetEmail(email));
             }
         });
@@ -98,26 +99,27 @@ public class RxFirebaseAuth {
 
     @NonNull
     public static Observable<FirebaseUser> observeAuthState(@NonNull final FirebaseAuth firebaseAuth) {
-
-        return Observable.create(new Observable.OnSubscribe<FirebaseUser>() {
+         return Observable.create(new ObservableOnSubscribe<FirebaseUser>() {
             @Override
-            public void call(final Subscriber<? super FirebaseUser> subscriber) {
+            public void subscribe(final ObservableEmitter<FirebaseUser> subscriber) throws Exception {
                 final FirebaseAuth.AuthStateListener authStateListener = new FirebaseAuth.AuthStateListener() {
                     @Override
-                    public void onAuthStateChanged(@NonNull FirebaseAuth firebaseAuth) {
-                        if (!subscriber.isUnsubscribed()) {
-                            subscriber.onNext(firebaseAuth.getCurrentUser());
+                    public void onAuthStateChanged(@NonNull FirebaseAuth updatedFirebaseAuth) {
+                        if (!subscriber.isDisposed()) {
+                            subscriber.onNext(updatedFirebaseAuth.getCurrentUser());
                         }
                     }
                 };
+
                 firebaseAuth.addAuthStateListener(authStateListener);
 
-                subscriber.add(Subscriptions.create(new Action0() {
-                    @Override
-                    public void call() {
+                subscriber.setCancellable(new Cancellable()
+                {
+                    @Override public void cancel() throws Exception
+                    {
                         firebaseAuth.removeAuthStateListener(authStateListener);
                     }
-                }));
+                });
             }
         });
     }

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseDatabase.java
@@ -9,66 +9,69 @@ import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
 import com.kelvinapps.rxfirebase.exceptions.RxFirebaseDataException;
 
-import rx.Observable;
-import rx.Subscriber;
-import rx.functions.Action0;
-import rx.functions.Func1;
-import rx.subscriptions.Subscriptions;
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.Maybe;
+import io.reactivex.functions.Cancellable;
+import io.reactivex.functions.Function;
 
 /**
  * Created by Nick Moskalenko on 15/05/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseDatabase {
 
     @NonNull
     public static Observable<DataSnapshot> observeValueEvent(final Query query) {
-        return Observable.create(new Observable.OnSubscribe<DataSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<DataSnapshot>() {
             @Override
-            public void call(final Subscriber<? super DataSnapshot> subscriber) {
+            public void subscribe(final ObservableEmitter<DataSnapshot> subscriber) throws Exception {
                 final ValueEventListener valueEventListener = query.addValueEventListener(
-                        new ValueEventListener() {
-                            @Override
-                            public void onDataChange(DataSnapshot dataSnapshot) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onNext(dataSnapshot);
-                                }
+                    new ValueEventListener() {
+                        @Override
+                        public void onDataChange(DataSnapshot dataSnapshot) {
+                            if (!subscriber.isDisposed()) {
+                                subscriber.onNext(dataSnapshot);
                             }
+                        }
 
-                            @Override
-                            public void onCancelled(final DatabaseError error) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onError(new RxFirebaseDataException(error));
-                                }
+                        @Override
+                        public void onCancelled(final DatabaseError error) {
+                            if (!subscriber.isDisposed()) {
+                                subscriber.onError(new RxFirebaseDataException(error));
                             }
-                        });
+                        }
+                    });
 
-                subscriber.add(Subscriptions.create(new Action0() {
-                    @Override
-                    public void call() {
-                        query.removeEventListener(valueEventListener);
-                    }
-                }));
+              subscriber.setCancellable(new Cancellable()
+              {
+                  @Override public void cancel() throws Exception
+                  {
+                    query.removeEventListener(valueEventListener);
+                  }
+              });
             }
         });
     }
 
     @NonNull
     public static Observable<DataSnapshot> observeSingleValueEvent(@NonNull final Query query) {
-        return Observable.create(new Observable.OnSubscribe<DataSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<DataSnapshot>() {
             @Override
-            public void call(final Subscriber<? super DataSnapshot> subscriber) {
+            public void subscribe(final ObservableEmitter<DataSnapshot> subscriber) throws Exception {
                 query.addListenerForSingleValueEvent(new ValueEventListener() {
                     @Override
                     public void onDataChange(DataSnapshot dataSnapshot) {
-                        if (!subscriber.isUnsubscribed()) {
+                        if (!subscriber.isDisposed()) {
                             subscriber.onNext(dataSnapshot);
-                            subscriber.onCompleted();
+                            subscriber.onComplete();
                         }
                     }
 
                     @Override
                     public void onCancelled(DatabaseError error) {
-                        if (!subscriber.isUnsubscribed()) {
+                        if (!subscriber.isDisposed()) {
                             subscriber.onError(new RxFirebaseDataException(error));
                         }
                     }
@@ -80,73 +83,73 @@ public class RxFirebaseDatabase {
     @NonNull
     public static Observable<RxFirebaseChildEvent<DataSnapshot>> observeChildEvent(
             @NonNull final Query query) {
-        return Observable.create(new Observable.OnSubscribe<RxFirebaseChildEvent<DataSnapshot>>() {
+        return Observable.create(new ObservableOnSubscribe<RxFirebaseChildEvent<DataSnapshot>>() {
             @Override
-            public void call(final Subscriber<? super RxFirebaseChildEvent<DataSnapshot>> subscriber) {
+            public void subscribe(final ObservableEmitter<RxFirebaseChildEvent<DataSnapshot>> subscriber) throws Exception {
                 final ChildEventListener childEventListener = query.addChildEventListener(
-                        new ChildEventListener() {
+                    new ChildEventListener() {
 
-                            @Override
-                            public void onChildAdded(DataSnapshot dataSnapshot, String previousChildName) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onNext(
-                                            new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot, previousChildName,
-                                                    RxFirebaseChildEvent.EventType.ADDED));
-                                }
+                        @Override
+                        public void onChildAdded(DataSnapshot dataSnapshot, String previousChildName) {
+                            if (!subscriber.isDisposed()) {
+                                subscriber.onNext(
+                                        new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot, previousChildName,
+                                                RxFirebaseChildEvent.EventType.ADDED));
                             }
+                        }
 
-                            @Override
-                            public void onChildChanged(DataSnapshot dataSnapshot, String previousChildName) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onNext(
-                                            new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot, previousChildName,
-                                                    RxFirebaseChildEvent.EventType.CHANGED));
-                                }
+                        @Override
+                        public void onChildChanged(DataSnapshot dataSnapshot, String previousChildName) {
+                            if (!subscriber.isDisposed()) {
+                                subscriber.onNext(
+                                        new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot, previousChildName,
+                                                RxFirebaseChildEvent.EventType.CHANGED));
                             }
+                        }
 
-                            @Override
-                            public void onChildRemoved(DataSnapshot dataSnapshot) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onNext(new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot,
-                                            RxFirebaseChildEvent.EventType.REMOVED));
-                                }
+                        @Override
+                        public void onChildRemoved(DataSnapshot dataSnapshot) {
+                            if (!subscriber.isDisposed()) {
+                                subscriber.onNext(new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot,
+                                        RxFirebaseChildEvent.EventType.REMOVED));
                             }
+                        }
 
-                            @Override
-                            public void onChildMoved(DataSnapshot dataSnapshot, String previousChildName) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onNext(
-                                            new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot, previousChildName,
-                                                    RxFirebaseChildEvent.EventType.MOVED));
-                                }
+                        @Override
+                        public void onChildMoved(DataSnapshot dataSnapshot, String previousChildName) {
+                            if (!subscriber.isDisposed()) {
+                                subscriber.onNext(
+                                        new RxFirebaseChildEvent<DataSnapshot>(dataSnapshot.getKey(), dataSnapshot, previousChildName,
+                                                RxFirebaseChildEvent.EventType.MOVED));
                             }
+                        }
 
-                            @Override
-                            public void onCancelled(DatabaseError error) {
-                                if (!subscriber.isUnsubscribed()) {
-                                    subscriber.onError(new RxFirebaseDataException(error));
-                                }
+                        @Override
+                        public void onCancelled(DatabaseError error) {
+                            if (!subscriber.isDisposed()) {
+                                subscriber.onError(new RxFirebaseDataException(error));
                             }
-                        });
-
-                subscriber.add(Subscriptions.create(new Action0() {
-                    @Override
-                    public void call() {
-                        query.removeEventListener(childEventListener);
-                    }
-                }));
+                        }
+                    });
+              subscriber.setCancellable(new Cancellable()
+              {
+                  @Override public void cancel() throws Exception
+                  {
+                    query.removeEventListener(childEventListener);
+                  }
+              });
             }
         });
     }
 
     @NonNull
-    public static <T> Observable<T> observeValueEvent(@NonNull final Query query,
-                                                      @NonNull final Class<T> clazz) {
+    public static <T> Observable<Maybe<T>> observeValueEvent(@NonNull final Query query,
+                                                           @NonNull final Class<T> clazz) {
         return observeValueEvent(query, DataSnapshotMapper.of(clazz));
     }
 
     @NonNull
-    public static <T> Observable<T> observeSingleValueEvent(@NonNull final Query query,
+    public static <T> Observable<Maybe<T>> observeSingleValueEvent(@NonNull final Query query,
                                                             @NonNull final Class<T> clazz) {
         return observeSingleValueEvent(query, DataSnapshotMapper.of(clazz));
     }
@@ -159,19 +162,19 @@ public class RxFirebaseDatabase {
 
     @NonNull
     public static <T> Observable<T> observeValueEvent(@NonNull final Query query,
-                                                      @NonNull final Func1<? super DataSnapshot, ? extends T> mapper) {
+                                                      @NonNull final Function<? super DataSnapshot, ? extends T> mapper) {
         return observeValueEvent(query).map(mapper);
     }
 
     @NonNull
     public static <T> Observable<T> observeSingleValueEvent(@NonNull final Query query,
-                                                            @NonNull final Func1<? super DataSnapshot, ? extends T> mapper) {
+                                                            @NonNull final Function<? super DataSnapshot, ? extends T> mapper) {
         return observeSingleValueEvent(query).map(mapper);
     }
 
     @NonNull
     public static <T> Observable<RxFirebaseChildEvent<T>> observeChildEvent(
-            @NonNull final Query query, @NonNull final Func1<? super RxFirebaseChildEvent<DataSnapshot>, ? extends RxFirebaseChildEvent<T>> mapper) {
+            @NonNull final Query query, @NonNull final Function<? super RxFirebaseChildEvent<DataSnapshot>, ? extends RxFirebaseChildEvent<T>> mapper) {
         return observeChildEvent(query).map(mapper);
     }
 }

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseStorage.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseStorage.java
@@ -9,33 +9,36 @@ import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.StreamDownloadTask;
 import com.google.firebase.storage.UploadTask;
 
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
 import java.io.File;
 import java.io.InputStream;
 
-import rx.Observable;
-import rx.Subscriber;
+import io.reactivex.Observable;
 
 /**
  * Created by Nick Moskalenko on 24/05/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseStorage {
 
     @NonNull
     public static Observable<byte[]> getBytes(@NonNull final StorageReference storageRef,
                                               final long maxDownloadSizeBytes) {
-        return Observable.create(new Observable.OnSubscribe<byte[]>() {
+        return Observable.create(new ObservableOnSubscribe<byte[]>() {
             @Override
-            public void call(final Subscriber<? super byte[]> subscriber) {
+            public void subscribe(ObservableEmitter<byte[]> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.getBytes(maxDownloadSizeBytes));
             }
         });
+
     }
 
     @NonNull
     public static Observable<Uri> getDownloadUrl(@NonNull final StorageReference storageRef) {
-        return Observable.create(new Observable.OnSubscribe<Uri>() {
+        return Observable.create(new ObservableOnSubscribe<Uri>() {
             @Override
-            public void call(final Subscriber<? super Uri> subscriber) {
+            public void subscribe(ObservableEmitter<Uri> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.getDownloadUrl());
             }
         });
@@ -44,9 +47,9 @@ public class RxFirebaseStorage {
     @NonNull
     public static Observable<FileDownloadTask.TaskSnapshot> getFile(@NonNull final StorageReference storageRef,
                                                                     @NonNull final File destinationFile) {
-        return Observable.create(new Observable.OnSubscribe<FileDownloadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<FileDownloadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super FileDownloadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<FileDownloadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.getFile(destinationFile));
             }
         });
@@ -55,9 +58,9 @@ public class RxFirebaseStorage {
     @NonNull
     public static Observable<FileDownloadTask.TaskSnapshot> getFile(@NonNull final StorageReference storageRef,
                                                                     @NonNull final Uri destinationUri) {
-        return Observable.create(new Observable.OnSubscribe<FileDownloadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<FileDownloadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super FileDownloadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<FileDownloadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.getFile(destinationUri));
             }
         });
@@ -65,9 +68,9 @@ public class RxFirebaseStorage {
 
     @NonNull
     public static Observable<StorageMetadata> getMetadata(@NonNull final StorageReference storageRef) {
-        return Observable.create(new Observable.OnSubscribe<StorageMetadata>() {
+        return Observable.create(new ObservableOnSubscribe<StorageMetadata>() {
             @Override
-            public void call(final Subscriber<? super StorageMetadata> subscriber) {
+            public void subscribe(ObservableEmitter<StorageMetadata> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.getMetadata());
             }
         });
@@ -75,9 +78,9 @@ public class RxFirebaseStorage {
 
     @NonNull
     public static Observable<StreamDownloadTask.TaskSnapshot> getStream(@NonNull final StorageReference storageRef) {
-        return Observable.create(new Observable.OnSubscribe<StreamDownloadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<StreamDownloadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super StreamDownloadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<StreamDownloadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.getStream());
             }
         });
@@ -86,9 +89,9 @@ public class RxFirebaseStorage {
     @NonNull
     public static Observable<StreamDownloadTask.TaskSnapshot> getStream(@NonNull final StorageReference storageRef,
                                                                         @NonNull final StreamDownloadTask.StreamProcessor processor) {
-        return Observable.create(new Observable.OnSubscribe<StreamDownloadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<StreamDownloadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super StreamDownloadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<StreamDownloadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.getStream(processor));
             }
         });
@@ -98,9 +101,9 @@ public class RxFirebaseStorage {
     @NonNull
     public static Observable<UploadTask.TaskSnapshot> putBytes(@NonNull final StorageReference storageRef,
                                                                @NonNull final byte[] bytes) {
-        return Observable.create(new Observable.OnSubscribe<UploadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<UploadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super UploadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<UploadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.putBytes(bytes));
             }
         });
@@ -110,9 +113,9 @@ public class RxFirebaseStorage {
     public static Observable<UploadTask.TaskSnapshot> putBytes(@NonNull final StorageReference storageRef,
                                                                @NonNull final byte[] bytes,
                                                                @NonNull final StorageMetadata metadata) {
-        return Observable.create(new Observable.OnSubscribe<UploadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<UploadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super UploadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<UploadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.putBytes(bytes, metadata));
             }
         });
@@ -121,9 +124,9 @@ public class RxFirebaseStorage {
     @NonNull
     public static Observable<UploadTask.TaskSnapshot> putFile(@NonNull final StorageReference storageRef,
                                                               @NonNull final Uri uri) {
-        return Observable.create(new Observable.OnSubscribe<UploadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<UploadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super UploadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<UploadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.putFile(uri));
             }
         });
@@ -133,9 +136,9 @@ public class RxFirebaseStorage {
     public static Observable<UploadTask.TaskSnapshot> putFile(@NonNull final StorageReference storageRef,
                                                               @NonNull final Uri uri,
                                                               @NonNull final StorageMetadata metadata) {
-        return Observable.create(new Observable.OnSubscribe<UploadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<UploadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super UploadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<UploadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.putFile(uri, metadata));
             }
         });
@@ -146,9 +149,9 @@ public class RxFirebaseStorage {
                                                               @NonNull final Uri uri,
                                                               @NonNull final StorageMetadata metadata,
                                                               @NonNull final Uri existingUploadUri) {
-        return Observable.create(new Observable.OnSubscribe<UploadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<UploadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super UploadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<UploadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.putFile(uri, metadata, existingUploadUri));
             }
         });
@@ -158,9 +161,9 @@ public class RxFirebaseStorage {
     public static Observable<UploadTask.TaskSnapshot> putStream(@NonNull final StorageReference storageRef,
                                                                 @NonNull final InputStream stream,
                                                                 @NonNull final StorageMetadata metadata) {
-        return Observable.create(new Observable.OnSubscribe<UploadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<UploadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super UploadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<UploadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.putStream(stream, metadata));
             }
         });
@@ -169,9 +172,9 @@ public class RxFirebaseStorage {
     @NonNull
     public static Observable<UploadTask.TaskSnapshot> putStream(@NonNull final StorageReference storageRef,
                                                                 @NonNull final InputStream stream) {
-        return Observable.create(new Observable.OnSubscribe<UploadTask.TaskSnapshot>() {
+        return Observable.create(new ObservableOnSubscribe<UploadTask.TaskSnapshot>() {
             @Override
-            public void call(final Subscriber<? super UploadTask.TaskSnapshot> subscriber) {
+            public void subscribe(ObservableEmitter<UploadTask.TaskSnapshot> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.putStream(stream));
             }
         });
@@ -180,9 +183,9 @@ public class RxFirebaseStorage {
     @NonNull
     public static Observable<StorageMetadata> updateMetadata(@NonNull final StorageReference storageRef,
                                                              @NonNull final StorageMetadata metadata) {
-        return Observable.create(new Observable.OnSubscribe<StorageMetadata>() {
+        return Observable.create(new ObservableOnSubscribe<StorageMetadata>() {
             @Override
-            public void call(final Subscriber<? super StorageMetadata> subscriber) {
+            public void subscribe(ObservableEmitter<StorageMetadata> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.updateMetadata(metadata));
             }
         });
@@ -190,9 +193,9 @@ public class RxFirebaseStorage {
 
     @NonNull
     public static Observable<Void> delete(@NonNull final StorageReference storageRef) {
-        return Observable.create(new Observable.OnSubscribe<Void>() {
+        return Observable.create(new ObservableOnSubscribe<Void>() {
             @Override
-            public void call(final Subscriber<? super Void> subscriber) {
+            public void subscribe(ObservableEmitter<Void> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, storageRef.delete());
             }
         });

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseUser.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxFirebaseUser.java
@@ -8,20 +8,22 @@ import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GetTokenResult;
 import com.google.firebase.auth.UserProfileChangeRequest;
 
-import rx.Observable;
-import rx.Subscriber;
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
 
 /**
  * Created by Nick Moskalenko on 24/05/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseUser {
 
     @NonNull
     public static Observable<GetTokenResult> getToken(@NonNull final FirebaseUser firebaseUser,
                                                       final boolean forceRefresh) {
-        return Observable.create(new Observable.OnSubscribe<GetTokenResult>() {
+        return Observable.create(new ObservableOnSubscribe<GetTokenResult>() {
             @Override
-            public void call(final Subscriber<? super GetTokenResult> subscriber) {
+            public void subscribe(ObservableEmitter<GetTokenResult> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseUser.getToken(forceRefresh));
             }
         });
@@ -30,9 +32,9 @@ public class RxFirebaseUser {
     @NonNull
     public static Observable<Void> updateEmail(@NonNull final FirebaseUser firebaseUser,
                                                @NonNull final String email) {
-        return Observable.create(new Observable.OnSubscribe<Void>() {
+        return Observable.create(new ObservableOnSubscribe<Void>() {
             @Override
-            public void call(final Subscriber<? super Void> subscriber) {
+            public void subscribe(ObservableEmitter<Void> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseUser.updateEmail(email));
             }
         });
@@ -41,9 +43,9 @@ public class RxFirebaseUser {
     @NonNull
     public static Observable<Void> updatePassword(@NonNull final FirebaseUser firebaseUser,
                                                   @NonNull final String password) {
-        return Observable.create(new Observable.OnSubscribe<Void>() {
+        return Observable.create(new ObservableOnSubscribe<Void>() {
             @Override
-            public void call(final Subscriber<? super Void> subscriber) {
+            public void subscribe(ObservableEmitter<Void> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseUser.updatePassword(password));
             }
         });
@@ -52,9 +54,9 @@ public class RxFirebaseUser {
     @NonNull
     public static Observable<Void> updateProfile(@NonNull final FirebaseUser firebaseUser,
                                                  @NonNull final UserProfileChangeRequest request) {
-        return Observable.create(new Observable.OnSubscribe<Void>() {
+        return Observable.create(new ObservableOnSubscribe<Void>() {
             @Override
-            public void call(final Subscriber<? super Void> subscriber) {
+            public void subscribe(ObservableEmitter<Void> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseUser.updateProfile(request));
             }
         });
@@ -62,9 +64,9 @@ public class RxFirebaseUser {
 
     @NonNull
     public static Observable<Void> delete(@NonNull final FirebaseUser firebaseUser) {
-        return Observable.create(new Observable.OnSubscribe<Void>() {
+        return Observable.create(new ObservableOnSubscribe<Void>() {
             @Override
-            public void call(final Subscriber<? super Void> subscriber) {
+            public void subscribe(ObservableEmitter<Void> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseUser.delete());
             }
         });
@@ -73,9 +75,9 @@ public class RxFirebaseUser {
     @NonNull
     public static Observable<Void> reauthenticate(@NonNull final FirebaseUser firebaseUser,
                                                   @NonNull final AuthCredential credential) {
-        return Observable.create(new Observable.OnSubscribe<Void>() {
+        return Observable.create(new ObservableOnSubscribe<Void>() {
             @Override
-            public void call(final Subscriber<? super Void> subscriber) {
+            public void subscribe(ObservableEmitter<Void> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseUser.reauthenticate(credential));
             }
         });
@@ -84,9 +86,9 @@ public class RxFirebaseUser {
     @NonNull
     public static Observable<AuthResult> linkWithCredential(@NonNull final FirebaseUser firebaseUser,
                                                             @NonNull final AuthCredential credential) {
-        return Observable.create(new Observable.OnSubscribe<AuthResult>() {
+        return Observable.create(new ObservableOnSubscribe<AuthResult>() {
             @Override
-            public void call(final Subscriber<? super AuthResult> subscriber) {
+            public void subscribe(ObservableEmitter<AuthResult> subscriber) throws Exception {
                 RxHandler.assignOnTask(subscriber, firebaseUser.linkWithCredential(credential));
             }
         });

--- a/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxHandler.java
+++ b/rxfirebase/src/main/java/com/kelvinapps/rxfirebase/RxHandler.java
@@ -7,20 +7,21 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 
-import rx.Subscriber;
+import io.reactivex.Emitter;
 
 /**
  * Created by Nick Moskalenko on 24/05/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxHandler<T> implements OnSuccessListener<T>, OnFailureListener, OnCompleteListener<T> {
 
-    private final Subscriber<? super T> subscriber;
+    private final Emitter<? super T> subscriber;
 
-    private RxHandler(Subscriber<? super T> observer) {
+    private RxHandler(Emitter<? super T> observer) {
         this.subscriber = observer;
     }
 
-    public static <T> void assignOnTask(Subscriber<? super T> observer, Task<T> task) {
+    public static <T> void assignOnTask(Emitter<? super T> observer, Task<T> task) {
         RxHandler handler = new RxHandler(observer);
         task.addOnSuccessListener(handler);
         task.addOnFailureListener(handler);
@@ -33,22 +34,16 @@ public class RxHandler<T> implements OnSuccessListener<T>, OnFailureListener, On
 
     @Override
     public void onSuccess(T res) {
-        if (!subscriber.isUnsubscribed()) {
-            subscriber.onNext(res);
-        }
+        subscriber.onNext(res);
     }
 
     @Override
     public void onComplete(@NonNull Task<T> task) {
-        if (!subscriber.isUnsubscribed()) {
-            subscriber.onCompleted();
-        }
+        subscriber.onComplete();
     }
 
     @Override
     public void onFailure(@NonNull Exception e) {
-        if (!subscriber.isUnsubscribed()) {
-            subscriber.onError(e);
-        }
+        subscriber.onError(e);
     }
 }

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseAuthTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseAuthTests.java
@@ -19,8 +19,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 
-import rx.observers.TestSubscriber;
-import rx.schedulers.Schedulers;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.Schedulers;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Created by Nick Moskalenko on 28/04/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseAuthTests {
 
@@ -58,7 +59,8 @@ public class RxFirebaseAuthTests {
     @Mock
     private FirebaseUser mockUser;
 
-    private Void mockRes = null;
+    enum Irrelevant { INSTANCE; }
+    private Irrelevant mockRes = Irrelevant.INSTANCE;
 
     private ArgumentCaptor<OnCompleteListener> testOnCompleteListener;
     private ArgumentCaptor<OnSuccessListener> testOnSuccessListener;
@@ -98,9 +100,9 @@ public class RxFirebaseAuthTests {
     @Test
     public void signInAnonymously() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.signInAnonymously(mockAuth)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockAuthResult);
@@ -110,17 +112,17 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockAuthResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockAuthResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void signInAnonymously_Failed() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.signInAnonymously(mockAuth)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         Exception e = new Exception("something bad happened");
@@ -129,16 +131,16 @@ public class RxFirebaseAuthTests {
         verify(mockAuth).signInAnonymously();
 
         testSubscriber.assertError(e);
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void signInWithEmailAndPassword() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.signInWithEmailAndPassword(mockAuth, "email", "password")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockAuthResult);
@@ -148,17 +150,17 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockAuthResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockAuthResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void signInWithEmailAndPassword_AuthError() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.signInWithEmailAndPassword(mockAuth, "email", "password")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         Exception e = new Exception("something bad happened");
@@ -167,16 +169,16 @@ public class RxFirebaseAuthTests {
         verify(mockAuth).signInWithEmailAndPassword(eq("email"), eq("password"));
 
         testSubscriber.assertError(e);
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void signInWithCredential() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.signInWithCredential(mockAuth, mockCredentials)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockAuthResult);
@@ -186,17 +188,17 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockAuthResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockAuthResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void signInWithCustomToken() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.signInWithCustomToken(mockAuth, "token")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockAuthResult);
@@ -206,17 +208,17 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockAuthResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockAuthResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void createUserWithEmailAndPassword() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.createUserWithEmailAndPassword(mockAuth, "email", "password")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockAuthResult);
@@ -226,17 +228,17 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockAuthResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockAuthResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void fetchProvidersForEmail() throws InterruptedException {
 
-        TestSubscriber<ProviderQueryResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<ProviderQueryResult> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.fetchProvidersForEmail(mockAuth, "email")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockProviderQueryResult);
@@ -246,17 +248,17 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockProviderQueryResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockProviderQueryResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void sendPasswordResetEmail() throws InterruptedException {
 
-        TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+        TestObserver<Object> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.sendPasswordResetEmail(mockAuth, "email")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockRes);
@@ -266,17 +268,17 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockRes));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockRes));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveAuthState() throws InterruptedException {
 
-        TestSubscriber<FirebaseUser> testSubscriber = new TestSubscriber<>();
+        TestObserver<FirebaseUser> testSubscriber = new TestObserver<>();
         RxFirebaseAuth.observeAuthState(mockAuth)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<FirebaseAuth.AuthStateListener> argument = ArgumentCaptor.forClass(FirebaseAuth.AuthStateListener.class);
@@ -285,8 +287,8 @@ public class RxFirebaseAuthTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockUser));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockUser));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 }

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseDatabaseTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseDatabaseTests.java
@@ -1,5 +1,6 @@
 package com.kelvinapps.rxfirebase;
 
+import android.support.annotation.NonNull;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -7,6 +8,8 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.ValueEventListener;
 import com.kelvinapps.rxfirebase.exceptions.RxFirebaseDataException;
 
+import io.reactivex.Maybe;
+import io.reactivex.functions.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -21,10 +24,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import rx.functions.Func0;
-import rx.functions.Func1;
-import rx.observers.TestSubscriber;
-import rx.schedulers.Schedulers;
+import java.util.concurrent.Callable;
+import io.reactivex.functions.Function;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.Schedulers;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -32,6 +35,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Created by Nick Moskalenko on 28/04/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseDatabaseTests {
 
@@ -41,9 +45,9 @@ public class RxFirebaseDatabaseTests {
     @Mock
     private DataSnapshot mockFirebaseDataSnapshot;
 
-    private TestData testData = new TestData();
-    private List<TestData> testDataList = new ArrayList<>();
-    private Map<String, TestData> testDataMap = new HashMap<>();
+    private Maybe<TestData> testData = Maybe.just(new TestData());
+    private List<Maybe<TestData>> testDataList = new ArrayList<>();
+    private Map<String, Maybe<TestData>> testDataMap = new HashMap<>();
 
     private RxFirebaseChildEvent<TestData> testChildEventAdded;
     private RxFirebaseChildEvent<TestData> testChildEventChanged;
@@ -56,13 +60,15 @@ public class RxFirebaseDatabaseTests {
 
         testDataList.add(testData);
         testDataMap.put("key", testData);
-        testChildEventAdded = new RxFirebaseChildEvent<>("key", testData, "root", RxFirebaseChildEvent.EventType.ADDED);
-        testChildEventChanged = new RxFirebaseChildEvent<>("key", testData, "root", RxFirebaseChildEvent.EventType.CHANGED);
-        testChildEventRemoved = new RxFirebaseChildEvent<>("key", testData, RxFirebaseChildEvent.EventType.REMOVED);
-        testChildEventMoved = new RxFirebaseChildEvent<>("key", testData, "root", RxFirebaseChildEvent.EventType.MOVED);
+
+        testChildEventAdded = new RxFirebaseChildEvent<>("key", testData.blockingGet(), "root", RxFirebaseChildEvent.EventType.ADDED);
+        testChildEventChanged = new RxFirebaseChildEvent<>("key", testData.blockingGet(), "root", RxFirebaseChildEvent.EventType.CHANGED);
+        testChildEventRemoved = new RxFirebaseChildEvent<>("key", testData.blockingGet(), RxFirebaseChildEvent.EventType.REMOVED);
+        testChildEventMoved = new RxFirebaseChildEvent<>("key", testData.blockingGet(), "root", RxFirebaseChildEvent.EventType.MOVED);
 
         when(mockFirebaseDataSnapshot.exists()).thenReturn(true);
-        when(mockFirebaseDataSnapshot.getValue(TestData.class)).thenReturn(testData);
+        when(mockFirebaseDataSnapshot.getValue(TestData.class)).thenReturn(testData.blockingGet());
+        when(mockFirebaseDataSnapshot.getValue(Maybe.class)).thenReturn(testData);
         when(mockFirebaseDataSnapshot.getKey()).thenReturn("key");
         when(mockFirebaseDataSnapshot.getChildren()).thenReturn(Arrays.asList(mockFirebaseDataSnapshot));
     }
@@ -70,9 +76,9 @@ public class RxFirebaseDatabaseTests {
     @Test
     public void testObserveSingleValue() throws InterruptedException {
 
-        TestSubscriber<TestData> testSubscriber = new TestSubscriber<>();
+        TestObserver<Maybe<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
@@ -81,9 +87,9 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testData));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValue(getMaybeEqualityPredicate(testData));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
@@ -92,9 +98,9 @@ public class RxFirebaseDatabaseTests {
         DataSnapshot mockFirebaseDataSnapshotNoData = mock(DataSnapshot.class);
         when(mockFirebaseDataSnapshotNoData.exists()).thenReturn(false);
 
-        TestSubscriber<TestData> testSubscriber = new TestSubscriber<>();
+        TestObserver<Maybe<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
@@ -103,16 +109,16 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveSingleWrongType() throws InterruptedException {
 
-        TestSubscriber<WrongType> testSubscriber = new TestSubscriber<>();
+        TestObserver<Maybe<WrongType>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase, WrongType.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
@@ -120,51 +126,51 @@ public class RxFirebaseDatabaseTests {
         argument.getValue().onDataChange(mockFirebaseDataSnapshot);
 
         testSubscriber.assertError(RuntimeException.class);
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveSingleValue_Disconnected() throws InterruptedException {
 
-        TestSubscriber<TestData> testSubscriber = new TestSubscriber<>();
+        TestObserver<Maybe<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
         verify(mockDatabase).addListenerForSingleValueEvent(argument.capture());
-        argument.getValue().onCancelled(DatabaseError.zzaer(DatabaseError.DISCONNECTED));
+        argument.getValue().onCancelled(DatabaseError.zzpI(DatabaseError.DISCONNECTED));
 
         testSubscriber.assertError(RxFirebaseDataException.class);
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveSingleValueEvent_Failed() throws InterruptedException {
 
-        TestSubscriber<List<TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<List<Maybe<TestData>>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .toList()
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
         verify(mockDatabase).addListenerForSingleValueEvent(argument.capture());
-        argument.getValue().onCancelled(DatabaseError.zzaer(DatabaseError.OPERATION_FAILED));
+        argument.getValue().onCancelled(DatabaseError.zzpI(DatabaseError.OPERATION_FAILED));
 
         testSubscriber.assertError(RxFirebaseDataException.class);
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveValueEvent() throws InterruptedException {
 
-        TestSubscriber<TestData> testSubscriber = new TestSubscriber<>();
+        TestObserver<Maybe<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeValueEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
@@ -173,17 +179,18 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testData));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValue(getMaybeEqualityPredicate(testData));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
+
 
     @Test
     public void testSingleValueEvent() throws InterruptedException {
 
-        TestSubscriber<TestData> testSubscriber = new TestSubscriber<>();
+        TestObserver<Maybe<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ValueEventListener> argument = ArgumentCaptor.forClass(ValueEventListener.class);
@@ -192,17 +199,17 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testData));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValue(getMaybeEqualityPredicate(testData));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveValueEventList() throws InterruptedException {
 
-        TestSubscriber<List<TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<List<Maybe<TestData>>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .toList()
                 .subscribe(testSubscriber);
 
@@ -212,31 +219,31 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testDataList));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValue(getListMaybeEqualityPredicate(testDataList));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveValuesMap() throws InterruptedException {
 
-        TestSubscriber<Map<String, TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<Map<String, Maybe<TestData>>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeSingleValueEvent(mockDatabase)
-                .subscribeOn(Schedulers.immediate())
-                .toMap(new Func1<DataSnapshot, String>() {
+                .subscribeOn(Schedulers.trampoline())
+                .toMap(new Function<DataSnapshot, String>() {
                     @Override
-                    public String call(DataSnapshot dataSnapshot) {
+                    public String apply(DataSnapshot dataSnapshot) {
                         return dataSnapshot.getKey();
                     }
-                }, new Func1<DataSnapshot, TestData>() {
+                }, new Function<DataSnapshot, Maybe<TestData>>() {
                     @Override
-                    public TestData call(DataSnapshot dataSnapshot) {
-                        return dataSnapshot.getValue(TestData.class);
+                    public Maybe<TestData> apply(DataSnapshot dataSnapshot) {
+                        return dataSnapshot.getValue(Maybe.class);
                     }
-                }, new Func0<Map<String, TestData>>() {
+                }, new Callable<Map<String, Maybe<TestData>>>() {
                     @Override
-                    public Map<String, TestData> call() {
-                        return new LinkedHashMap<String, TestData>();
+                    public Map<String, Maybe<TestData>> call() {
+                        return new LinkedHashMap<String, Maybe<TestData>>();
                     }
                 })
                 .subscribe(testSubscriber);
@@ -247,17 +254,17 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testDataMap));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValue(getMapMaybeEqualityPredicate(testDataMap));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveChildEvent_Added() throws InterruptedException {
 
-        TestSubscriber<RxFirebaseChildEvent<TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<RxFirebaseChildEvent<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeChildEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ChildEventListener> argument = ArgumentCaptor.forClass(ChildEventListener.class);
@@ -266,17 +273,17 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testChildEventAdded));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(testChildEventAdded));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveChildEvent_Changed() throws InterruptedException {
 
-        TestSubscriber<RxFirebaseChildEvent<TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<RxFirebaseChildEvent<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeChildEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ChildEventListener> argument = ArgumentCaptor.forClass(ChildEventListener.class);
@@ -285,17 +292,17 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testChildEventChanged));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(testChildEventChanged));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveChildEvent_Removed() throws InterruptedException {
 
-        TestSubscriber<RxFirebaseChildEvent<TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<RxFirebaseChildEvent<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeChildEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ChildEventListener> argument = ArgumentCaptor.forClass(ChildEventListener.class);
@@ -304,17 +311,17 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testChildEventRemoved));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(testChildEventRemoved));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveChildEvent_Moved() throws InterruptedException {
 
-        TestSubscriber<RxFirebaseChildEvent<TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<RxFirebaseChildEvent<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeChildEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ChildEventListener> argument = ArgumentCaptor.forClass(ChildEventListener.class);
@@ -323,26 +330,26 @@ public class RxFirebaseDatabaseTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(testChildEventMoved));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(testChildEventMoved));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void testObserveChildEvent_Cancelled() throws InterruptedException {
 
-        TestSubscriber<RxFirebaseChildEvent<TestData>> testSubscriber = new TestSubscriber<>();
+        TestObserver<RxFirebaseChildEvent<TestData>> testSubscriber = new TestObserver<>();
         RxFirebaseDatabase.observeChildEvent(mockDatabase, TestData.class)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         ArgumentCaptor<ChildEventListener> argument = ArgumentCaptor.forClass(ChildEventListener.class);
         verify(mockDatabase).addChildEventListener(argument.capture());
-        argument.getValue().onCancelled(DatabaseError.zzaer(DatabaseError.DISCONNECTED));
+        argument.getValue().onCancelled(DatabaseError.zzpI(DatabaseError.DISCONNECTED));
 
         testSubscriber.assertError(RxFirebaseDataException.class);
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     class TestData {
@@ -353,5 +360,60 @@ public class RxFirebaseDatabaseTests {
     class WrongType {
         String somethingWrong;
         long more;
+    }
+
+    @NonNull private <T> Predicate<Maybe<T>> getMaybeEqualityPredicate(final Maybe<T> correctMaybeValue)
+    {
+        return new Predicate<Maybe<T>>()
+        {
+            @Override public boolean test(Maybe<T> testMaybeValue) throws Exception
+            {
+                if(testMaybeValue.isEmpty().blockingGet() == correctMaybeValue.isEmpty().blockingGet()){
+                    if(testMaybeValue.isEmpty().blockingGet())
+                        return true;
+                    else
+                        return correctMaybeValue.blockingGet().equals(testMaybeValue.blockingGet());
+                } else
+                    return false;
+            }
+        };
+    }
+
+    @NonNull private <T> Predicate<List<Maybe<T>>> getListMaybeEqualityPredicate(final List<Maybe<T>> correctMaybeValues)
+    {
+        return new Predicate<List<Maybe<T>>>()
+        {
+            @Override public boolean test(List<Maybe<T>> maybes) throws Exception
+            {
+                if(correctMaybeValues.size() == maybes.size()){
+                    for (int i = 0; i < correctMaybeValues.size(); i++)
+                    {
+                        if(! getMaybeEqualityPredicate(correctMaybeValues.get(i)).test(maybes.get(i)))
+                            return false;
+                    }
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+    @NonNull private <T> Predicate<Map<String, Maybe<T>>> getMapMaybeEqualityPredicate(final Map<String, Maybe<T>> correctMaybeValues)
+    {
+        return new Predicate<Map<String, Maybe<T>>>()
+        {
+            @Override public boolean test(Map<String, Maybe<T>> maybes) throws Exception
+            {
+                if(correctMaybeValues.size() == maybes.size() && correctMaybeValues.keySet().equals(maybes.keySet())){
+                    for (String key: correctMaybeValues.keySet())
+                    {
+                        if(! getMaybeEqualityPredicate(correctMaybeValues.get(key)).test(maybes.get(key)))
+                            return false;
+                    }
+                    return true;
+                }
+                return false;
+            }
+        };
     }
 }

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseStorageTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseStorageTests.java
@@ -22,14 +22,15 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Collections;
 
-import rx.observers.TestSubscriber;
-import rx.schedulers.Schedulers;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.Schedulers;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Created by Nick Moskalenko on 25/05/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseStorageTests {
 
@@ -81,7 +82,7 @@ public class RxFirebaseStorageTests {
     private UploadTask.TaskSnapshot uploadSnapshot;
 
 
-    private byte[] bytes;
+    private byte[] bytes = new byte[1];
 
     @Mock
     private StreamDownloadTask.StreamProcessor processor;
@@ -89,7 +90,8 @@ public class RxFirebaseStorageTests {
     @Mock
     private InputStream stream;
 
-    private Void voidData = null;
+    enum Irrelevant { INSTANCE; }
+    private Object voidData = Irrelevant.INSTANCE;
 
 
 
@@ -138,9 +140,9 @@ public class RxFirebaseStorageTests {
     @Test
     public void getBytes() throws InterruptedException {
 
-        TestSubscriber<byte[]> testSubscriber = new TestSubscriber<>();
+        TestObserver<byte[]> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.getBytes(mockStorageRef, 20)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(bytes);
@@ -150,17 +152,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(bytes));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(bytes));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void getDownloadUrl() throws InterruptedException {
 
-        TestSubscriber<Uri> testSubscriber = new TestSubscriber<>();
+        TestObserver<Uri> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.getDownloadUrl(mockStorageRef)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uri);
@@ -170,17 +172,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uri));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uri));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void getFile() throws InterruptedException {
 
-        TestSubscriber<FileDownloadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<FileDownloadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.getFile(mockStorageRef, file)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(fileSnapshot);
@@ -189,17 +191,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(fileSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(fileSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void getFileUri() throws InterruptedException {
 
-        TestSubscriber<FileDownloadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<FileDownloadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.getFile(mockStorageRef, uri)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(fileSnapshot);
@@ -208,18 +210,18 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(fileSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(fileSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
 
     @Test
     public void getMetadata() throws InterruptedException {
 
-        TestSubscriber<StorageMetadata> testSubscriber = new TestSubscriber<>();
+        TestObserver<StorageMetadata> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.getMetadata(mockStorageRef)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(metadata);
@@ -229,18 +231,18 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(metadata));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(metadata));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
 
     @Test
     public void getStream() throws InterruptedException {
 
-        TestSubscriber<StreamDownloadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<StreamDownloadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.getStream(mockStorageRef)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(streamSnapshot);
@@ -249,17 +251,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(streamSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(streamSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void getStreamProcessor() throws InterruptedException {
 
-        TestSubscriber<StreamDownloadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<StreamDownloadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.getStream(mockStorageRef, processor)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(streamSnapshot);
@@ -268,17 +270,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(streamSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(streamSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void putBytes() throws InterruptedException {
 
-        TestSubscriber<UploadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<UploadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.putBytes(mockStorageRef, bytes)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uploadSnapshot);
@@ -287,17 +289,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uploadSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uploadSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void putBytesMetadata() throws InterruptedException {
 
-        TestSubscriber<UploadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<UploadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.putBytes(mockStorageRef, bytes, metadata)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uploadSnapshot);
@@ -306,17 +308,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uploadSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uploadSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void putFile() throws InterruptedException {
 
-        TestSubscriber<UploadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<UploadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.putFile(mockStorageRef, uri)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uploadSnapshot);
@@ -325,17 +327,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uploadSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uploadSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void putFileMetadata() throws InterruptedException {
 
-        TestSubscriber<UploadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<UploadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.putFile(mockStorageRef, uri, metadata)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uploadSnapshot);
@@ -344,17 +346,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uploadSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uploadSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void putFileMetadataAndUri() throws InterruptedException {
 
-        TestSubscriber<UploadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<UploadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.putFile(mockStorageRef, uri, metadata, uri)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uploadSnapshot);
@@ -363,17 +365,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uploadSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uploadSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void putStream() throws InterruptedException {
 
-        TestSubscriber<UploadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<UploadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.putStream(mockStorageRef, stream)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uploadSnapshot);
@@ -382,17 +384,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uploadSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uploadSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void putStreamMetadata() throws InterruptedException {
 
-        TestSubscriber<UploadTask.TaskSnapshot> testSubscriber = new TestSubscriber<>();
+        TestObserver<UploadTask.TaskSnapshot> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.putStream(mockStorageRef, stream, metadata)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(uploadSnapshot);
@@ -401,17 +403,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(uploadSnapshot));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(uploadSnapshot));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void updateMetadata() throws InterruptedException {
 
-        TestSubscriber<StorageMetadata> testSubscriber = new TestSubscriber<>();
+        TestObserver<StorageMetadata> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.updateMetadata(mockStorageRef, metadata)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(metadata);
@@ -420,17 +422,17 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(metadata));
-        testSubscriber.assertNotCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(metadata));
+        testSubscriber.assertNotComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void delete() throws InterruptedException {
 
-        TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+        TestObserver<Object> testSubscriber = new TestObserver<>();
         RxFirebaseStorage.delete(mockStorageRef)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(voidData);
@@ -440,9 +442,9 @@ public class RxFirebaseStorageTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(voidData));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(voidData));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
 

--- a/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseUserTests.java
+++ b/rxfirebase/src/test/java/com/kelvinapps/rxfirebase/RxFirebaseUserTests.java
@@ -18,14 +18,15 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 
-import rx.observers.TestSubscriber;
-import rx.schedulers.Schedulers;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.schedulers.Schedulers;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Created by Nick Moskalenko on 24/05/2016.
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
  */
 public class RxFirebaseUserTests {
 
@@ -52,8 +53,8 @@ public class RxFirebaseUserTests {
     @Mock
     private GetTokenResult tokenResult;
 
-
-    private Void mockRes = null;
+    enum Irrelevant { INSTANCE; }
+    private Object mockRes = Irrelevant.INSTANCE;
 
     @Mock
     AuthCredential credential;
@@ -94,9 +95,9 @@ public class RxFirebaseUserTests {
     @Test
     public void getToken() throws InterruptedException {
 
-        TestSubscriber<GetTokenResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<GetTokenResult> testSubscriber = new TestObserver<>();
         RxFirebaseUser.getToken(mockUser, true)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(tokenResult);
@@ -106,17 +107,17 @@ public class RxFirebaseUserTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(tokenResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(tokenResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void updateEmail() throws InterruptedException {
 
-        TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+        TestObserver<Object> testSubscriber = new TestObserver<>();
         RxFirebaseUser.updateEmail(mockUser, "newemail")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockRes);
@@ -126,17 +127,17 @@ public class RxFirebaseUserTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockRes));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockRes));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void updatePassword() throws InterruptedException {
 
-        TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+        TestObserver<Object> testSubscriber = new TestObserver<>();
         RxFirebaseUser.updatePassword(mockUser, "password")
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockRes);
@@ -146,17 +147,17 @@ public class RxFirebaseUserTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockRes));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockRes));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void updateProfile() throws InterruptedException {
 
-        TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+        TestObserver<Object> testSubscriber = new TestObserver<>();
         RxFirebaseUser.updateProfile(mockUser, userProfileChangeRequest)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockRes);
@@ -166,17 +167,17 @@ public class RxFirebaseUserTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockRes));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockRes));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void delete() throws InterruptedException {
 
-        TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+        TestObserver<Object> testSubscriber = new TestObserver<>();
         RxFirebaseUser.delete(mockUser)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockRes);
@@ -186,17 +187,17 @@ public class RxFirebaseUserTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockRes));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockRes));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void reauthenticate() throws InterruptedException {
 
-        TestSubscriber<Void> testSubscriber = new TestSubscriber<>();
+        TestObserver<Object> testSubscriber = new TestObserver<>();
         RxFirebaseUser.reauthenticate(mockUser, credential)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(mockRes);
@@ -206,17 +207,17 @@ public class RxFirebaseUserTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(mockRes));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(mockRes));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 
     @Test
     public void linkWithCredential() throws InterruptedException {
 
-        TestSubscriber<AuthResult> testSubscriber = new TestSubscriber<>();
+        TestObserver<AuthResult> testSubscriber = new TestObserver<>();
         RxFirebaseUser.linkWithCredential(mockUser, credential)
-                .subscribeOn(Schedulers.immediate())
+                .subscribeOn(Schedulers.trampoline())
                 .subscribe(testSubscriber);
 
         testOnSuccessListener.getValue().onSuccess(authResult);
@@ -226,8 +227,8 @@ public class RxFirebaseUserTests {
 
         testSubscriber.assertNoErrors();
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertReceivedOnNext(Collections.singletonList(authResult));
-        testSubscriber.assertCompleted();
-        testSubscriber.unsubscribe();
+        testSubscriber.assertValueSequence(Collections.singletonList(authResult));
+        testSubscriber.assertComplete();
+        testSubscriber.dispose();
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -33,11 +33,11 @@ android {
 
 dependencies {
     compile project(':rxfirebase')
-    compile 'com.google.firebase:firebase-auth:9.4.0'
-    compile 'com.google.firebase:firebase-database:9.4.0'
-    compile 'com.google.firebase:firebase-storage:9.4.0'
+    compile 'com.google.firebase:firebase-auth:10.0.1'
+    compile 'com.google.firebase:firebase-database:10.0.1'
+    compile 'com.google.firebase:firebase-storage:10.0.1'
     compile 'com.android.support:appcompat-v7:24.1.1'
-    compile 'io.reactivex:rxandroid:1.2.1'
+    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/sample/src/main/java/kelvinapps/com/sample/SampleActivity.java
+++ b/sample/src/main/java/kelvinapps/com/sample/SampleActivity.java
@@ -24,6 +24,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * Adapted to RxJava 2 by Remous-Aris Koutsiamanis on 13/02/2017.
+ */
+
 public class SampleActivity extends AppCompatActivity {
 
     @Override
@@ -99,7 +103,7 @@ public class SampleActivity extends AppCompatActivity {
         // observe single user "nick"
         RxFirebaseDatabase.observeSingleValueEvent(reference.child("users").child("nick"), DataSnapshotMapper.of(User.class))
                 .subscribe(user -> {
-                    userTextView.setText(user.toString());
+                    userTextView.setText(user.blockingGet().toString());
                 }, throwable -> {
                     Toast.makeText(SampleActivity.this, throwable.toString(), Toast.LENGTH_LONG).show();
                 });
@@ -109,7 +113,7 @@ public class SampleActivity extends AppCompatActivity {
         // observe single user "nick"
         RxFirebaseDatabase.observeSingleValueEvent(reference.child("users").child("nick"), User.class)
                 .subscribe(user -> {
-                    userTextView.setText(user.toString());
+                    userTextView.setText(user.blockingGet().toString());
                 }, throwable -> {
                     Toast.makeText(SampleActivity.this, throwable.toString(), Toast.LENGTH_LONG).show();
                 });
@@ -119,8 +123,8 @@ public class SampleActivity extends AppCompatActivity {
         // try to observe non-existed value - would return null
         RxFirebaseDatabase.observeSingleValueEvent(reference.child("users").child("unknown"), User.class)
                 .subscribe(user -> {
-                    if (user != null) {
-                        userTextView.setText(user.toString());
+                    if (!user.isEmpty().blockingGet()) {
+                        userTextView.setText(user.blockingGet().toString());
                     } else {
                         userTextView.setText(userTextView.getText().toString() + "\nno such user");
                     }


### PR DESCRIPTION
Addressing #19, I have attempted to make the conversion to RxJava 2. I'm still relevantly new to RxJava, so I may have missed some of the more subtle behaviours. This has been a manual but relatively mechanical conversion. I have been using the library without problem in a new app.
This can be merged as a separate branch (keeping the same package name) but I have been using com.kelvinapps.rxfirebase2 as the package name internally. I can rename the package or change to a different major version if requested.

Changes:
Also convert tests and sample app.
Keep package name the same.
Add extra copyright notices.
io.reactivex.Maybe used in lieu of a proper Optional type, to avoid depending on java 8 Optional or StreamSupport Optional.
Update android gradle plugin version to 2.2.0 to avoid missing "value  @integer/google_play_services_version'" error.
Update firebase libraries to latest 10.0.1 version.